### PR TITLE
Updated the Scaliper dependencies to the most recent version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val commonSettings = Seq(
 
   resolvers += Resolver.bintrayRepo("azavea", "maven"),
   libraryDependencies ++= Seq(
-    "com.azavea" %% "scaliper" % "0.5.0-SNAPSHOT" % "test",
+    "com.azavea" %% "scaliper" % "0.5.0-c52f8a9" % "test",
     "org.scalatest"       %%  "scalatest"      % Version.scalaTest % "test"
   ),
 


### PR DESCRIPTION
The default dependency path didn't work for, citing that it could not find scaliper. I updated its path so that it reflects the most up-to-date version on BitBucket [here](https://bintray.com/azavea/maven/scaliper/view)